### PR TITLE
HOTFIX: Removed dependency on specific version of Chef

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -35,7 +35,6 @@ Vagrant.configure("2") do |config|
       node.vm.hostname = machine[:hostname]
       node.vm.network :forwarded_port, guest: 22, host: machine[:ssh_port], id: "ssh"
       node.vm.provision "chef_zero" do |chef|
-        chef.version = "12.10.24"
         chef.cookbooks_path = "cookbooks"
         chef.data_bags_path = "data_bags"
         chef.nodes_path = "nodes"


### PR DESCRIPTION
Testing on a second machine discovered a dependency problem with Chef.

ERROR 404
Omnitruck artifact does not exist for version 12.10.24 on platform ubuntu
